### PR TITLE
Version-suffix the content ID bases.

### DIFF
--- a/rst/dev-guide/cloud-bigdata-v1/_deconst.json
+++ b/rst/dev-guide/cloud-bigdata-v1/_deconst.json
@@ -1,3 +1,3 @@
 {
-  "contentIDBase": "https://github.com/rackerlabs/docs-cloud-big-data/"
+  "contentIDBase": "https://github.com/rackerlabs/docs-cloud-big-data/v1/"
 }

--- a/rst/dev-guide/cloud-bigdata-v2/_deconst.json
+++ b/rst/dev-guide/cloud-bigdata-v2/_deconst.json
@@ -1,3 +1,3 @@
 {
-  "contentIDBase": "https://github.com/rackerlabs/docs-cloud-big-data/"
+  "contentIDBase": "https://github.com/rackerlabs/docs-cloud-big-data/v2/"
 }


### PR DESCRIPTION
This makes the content ID bases used in the deconst build to be consistent with docs-cloud-backup.