### PR TITLE
Replaced incorrect reference to Cloud Databases

### DIFF
--- a/api-docs/cloud-bigdata-v2/index.rst
+++ b/api-docs/cloud-bigdata-v2/index.rst
@@ -6,7 +6,7 @@ Cloud Big Data API, v2.0
 
 *Last updated:* |today|
 
-Use the following links to get user and reference information for using the Rackspace Cloud Databases service 
+Use the following links to get user and reference information for using the |apiservice| service 
 REST API. 
 
 - :ref:`Getting Started Guide <getting-started>`


### PR DESCRIPTION
Replaced intro sentence reference to variable to correct incorrect specific reference to wrong product.